### PR TITLE
DL-17560: Rectifying the contrast of details section in result page

### DIFF
--- a/app/views/home/result.scala.html
+++ b/app/views/home/result.scala.html
@@ -49,14 +49,14 @@
 <div class="govuk-form-group">
     <strong class="govuk-body govuk-!-font-weight-bold">@Messages("result.para.1")</strong>
 
-    <section class="govuk-form-group">
-        <details>
-            <summary><span class="summary">@messages("result.accordion.question")</span></summary>
-            <div class="govuk-inset-text">
-                <p class="govuk-body">@messages("result.accordion.summary")</p>
-            </div>
-        </details>
-    </section>
+		<section class="govuk-form-group">
+				<details class="govuk-details">
+						<summary><span class="govuk-details__summary-text">@messages("result.accordion.question")</span></summary>
+						<div class="govuk-inset-text">
+								<p class="govuk-body">@messages("result.accordion.summary")</p>
+						</div>
+				</details>
+		</section>
 </div>
 <div class="govuk-form-group">
     <h2 class="govuk-heading-m">@Messages("result.heading.2")</h2>

--- a/test/views/home/resultViewSpec.scala
+++ b/test/views/home/resultViewSpec.scala
@@ -55,7 +55,7 @@ class ResultViewSpec extends PlaySpec with GuiceOneAppPerSuite with ResultViewMe
     }
 
     "have a progressive disclosure" in {
-      doc.select("span.summary").text() shouldBe ResultProgressiveDisclosureTitle
+      doc.select("span.govuk-details__summary-text").text() shouldBe ResultProgressiveDisclosureTitle
     }
 
     "have text within progressive disclosure" in {


### PR DESCRIPTION
DL-17560: Rectifying the contrast of details section in result page

Bug fix 

## Checklist

 - [ ]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [ ]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [ ]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
